### PR TITLE
Configure GoReleaser for GoDoctor packaging

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,40 @@
+# .goreleaser.yaml
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    main: ./cmd/godoctor
+    binary: bin/godoctor
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ if eq .Os "windows" }}win32{{ else }}{{ .Os }}{{ end }}.{{ if eq .Arch "amd64" }}x64{{ else if eq .Arch "386" }}ia32{{ else }}{{ .Arch }}{{ end }}.{{ .ProjectName }}
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - gemini-extension.json
+      - GODOCTOR.md
+      - README.md
+      - LICENSE
+      - skills/**/*
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,10 @@ test-cov:
 	$(GOTEST) -v -coverprofile=coverage.out ./...
 	@echo "to view the coverage report, run: go tool cover -html=coverage.out"
 
-.PHONY: all build install clean test test-cov
+snapshot:
+	goreleaser release --snapshot --clean
+
+release:
+	goreleaser release --clean
+
+.PHONY: all build install clean test test-cov snapshot release

--- a/README.md
+++ b/README.md
@@ -33,14 +33,9 @@ GoDoctor organizes its capabilities into domain-specific tools to streamline dev
 
 If you use the [Gemini CLI](https://github.com/google/gemini-cli), you can install GoDoctor as an extension. This is the easiest way for most Go developers to use it.
 
-1.  **Install the binary:**
-    ```bash
-    go install github.com/danicat/godoctor/cmd/godoctor@latest
-    ```
-2.  **Install the extension:**
-    ```bash
-    gemini extensions install https://github.com/danicat/godoctor
-    ```
+```bash
+gemini extensions install https://github.com/danicat/godoctor
+```
 
 ### For GoDoctor Developers
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "godoctor",
-  "version": "0.9.0",
-  "description": "AI-powered Go development assistant. Requires 'godoctor' to be installed via 'go install github.com/danicat/godoctor@latest'.",
+  "version": "0.11.0",
+  "description": "AI-powered Go development assistant.",
   "contextFileName": "GODOCTOR.md",
   "mcpServers": {
     "godoctor": {


### PR DESCRIPTION
Configured GoReleaser to automate the packaging and release of the godoctor extension.
The binary is now packaged into a `bin/` directory within the extension archive, matching the `gemini-extension.json` configuration.
Deprecated manual installation steps were removed from the README and extension description.
Added `snapshot` and `release` targets to the Makefile for easier release management.

Fixes #6

---
*PR created automatically by Jules for task [15282426255208337968](https://jules.google.com/task/15282426255208337968) started by @danicat*